### PR TITLE
Flesh out contribtuting instructions + Linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.0.1
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - types-PyYAML
+  - repo: https://github.com/nbQA-dev/nbQA
+    rev: 1.6.3
+    hooks:
+      - id: nbqa-black
+      - id: nbqa-isort
+      - id: nbqa-mypy
+        args: [ --ignore-missing-imports ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,24 @@ $ conda activate seasons
 
 ## Building
 
-Building the pack requires some vanilla files to derive the default values from. Create a 'vanilla' folder and
-copy the default 'foliage.png' and 'grass.png' files from the vanilla resource pack into it. Then
-copy the entire 'worldgen/biome' folder from the vanilla data pack into the folder as 'biome'.
+Building the pack requires some vanilla files to derive the default values from (as they are copyrighted
+parts of the official game they cannot be included in this repo).
 
-Run the script without any arguments:
+Start by Create a folder named 'vanilla'.
+
+Then find a copy of the default / vanilla resource pack and extract the files `foliage.pnmg` and `grass.png`
+from the `textures/colormap` folder and place them directly in the `vanilla` directory. These can be found
+within the minecraft assets, but versions of the vanilla resource pack are commonly available, and as these
+files change infrequently, it's not essential to have the most up-to-date version.
+
+Next you'll need to obtain the `biome` folder from the default data pack. The easiest way to obtain
+this is by extracting it directly from the Minecraft client JAR. **These files need to be from the same
+version you'll be using your datapack with!** Within the Minecraft JAR, the `biome` folder can be found
+within `data/minecraft/worlgen`. Extract the **entire folder** (including the `biome` folder itself) to
+the `vanilla` folder in this repo.
+
+Once you've obtained all the vanilla files and placed them in the right place,
+Run the build script without any arguments:
 
 `python build.py`
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,14 @@ and please consider making pull requests for fixes upstream.
 ## Developing
 
 If you want to develop your own modifications to the pack, you might need to modify and/or run the
-generator. This requires that you have python 3 installed, as well as libraries used:
+generator. This requires that you have python 3 installed, as well as the `imageio` library, which you
+can install via:
 
-`pip3 install imageio`
+```bash
+$ python3 -m pip install imageio
+```
 
-If you don't have python installed on your system, you can set up  a portable conda-based distribution
+If you don't have python or pip installed on your system, you can set up a portable conda-based distribution
 such as [mambaforge](https://github.com/conda-forge/miniforge#mambaforge) and then create
 a dedicated development environment by nagivating to the root folder of this project and running:
 
@@ -29,27 +32,25 @@ You can then activate that environment using:
 $ conda activate seasons
 ```
 
-
 ## Building
 
 Building the pack requires some vanilla files to derive the default values from (as they are copyrighted
 parts of the official game they cannot be included in this repo).
 
-Start by Create a folder named 'vanilla'.
-
-Then find a copy of the default / vanilla resource pack and extract the files `foliage.pnmg` and `grass.png`
+1. Start by creating a folder named `vanilla` in the project root.
+1. Then find a copy of the default / vanilla resource pack and extract the files `foliage.pnmg` and `grass.png`
 from the `textures/colormap` folder and place them directly in the `vanilla` directory. These can be found
 within the minecraft assets, but versions of the vanilla resource pack are commonly available, and as these
 files change infrequently, it's not essential to have the most up-to-date version.
-
-Next you'll need to obtain the `biome` folder from the default data pack. The easiest way to obtain
+1. Next you'll need to obtain the `biome` folder from the default data pack. The easiest way to obtain
 this is by extracting it directly from the Minecraft client JAR. **These files need to be from the same
 version you'll be using your datapack with!** Within the Minecraft JAR, the `biome` folder can be found
 within `data/minecraft/worlgen`. Extract the **entire folder** (including the `biome` folder itself) to
 the `vanilla` folder in this repo.
 
 Once you've obtained all the vanilla files and placed them in the right place,
-Run the build script without any arguments:
+run the build script without any arguments:
 
-`python build.py`
-
+```bash
+python build.py
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ design changes to include. Make sure to include full descriptions of changes.
 If you fork this and make your own version of it, please retain some form of credit to slicedlime,
 and please consider making pull requests for fixes upstream.
 
+
 ## Developing
 
 If you want to develop your own modifications to the pack, you might need to modify and/or run the
@@ -13,7 +14,25 @@ generator. This requires that you have python 3 installed, as well as libraries 
 
 `pip3 install imageio`
 
-It requires some vanilla files to derive the default values from. Create a 'vanilla' folder and
+If you don't have python installed on your system, you can set up  a portable conda-based distribution
+such as [mambaforge](https://github.com/conda-forge/miniforge#mambaforge) and then create
+a dedicated development environment by nagivating to the root folder of this project and running:
+
+```bash
+$ mamba env create
+```
+(subsitute `conda` if needed).
+
+You can then activate that environment using:
+
+```bash
+$ conda activate seasons
+```
+
+
+## Building
+
+Building the pack requires some vanilla files to derive the default values from. Create a 'vanilla' folder and
 copy the default 'foliage.png' and 'grass.png' files from the vanilla resource pack into it. Then
 copy the entire 'worldgen/biome' folder from the vanilla data pack into the folder as 'biome'.
 

--- a/build.py
+++ b/build.py
@@ -3,30 +3,32 @@ import json
 import os
 import os.path as path
 import pathlib
+from colorsys import hsv_to_rgb, rgb_to_hsv
+from typing import Any
+
 import imageio.v3 as imageio
 import numpy.typing
-from colorsys import rgb_to_hsv, hsv_to_rgb
 
-template_folder = 'templates'
-output_folder = 'data/seasons/functions/generated'
+template_folder = "templates"
+output_folder = "data/seasons/functions/generated"
 
-vanilla_biome_folder = 'vanilla/biome'
-vanilla_grass_texture = 'vanilla/grass.png'
-vanilla_foliage_texture = 'vanilla/foliage.png'
+vanilla_biome_folder = "vanilla/biome"
+vanilla_grass_texture = "vanilla/grass.png"
+vanilla_foliage_texture = "vanilla/foliage.png"
 
-tag_file = 'data/seasons/tags/blocks/snowable_plants.json'
-biome_tag_folder = 'data/seasons/tags/worldgen/biome'
-biome_folder = 'data/seasons/worldgen/biome'
+tag_file = "data/seasons/tags/blocks/snowable_plants.json"
+biome_tag_folder = "data/seasons/tags/worldgen/biome"
+biome_folder = "data/seasons/worldgen/biome"
 
-seasons = ['summer', 'fall', 'winter', 'spring']
+seasons = ["summer", "fall", "winter", "spring"]
 
 # Constants
 
-snowy_ground = 'F4FEFF'
+snowy_ground = "F4FEFF"
 
-flowering_leaves = 'FF8CAF'
-winter_branches = '7C6952'
-snowy_leaves = 'FFFFFF'
+flowering_leaves = "FF8CAF"
+winter_branches = "7C6952"
+snowy_leaves = "FFFFFF"
 
 fall_grass = [-25, -25, -5]
 winter_grass = [-27, -55, -5]
@@ -45,17 +47,13 @@ winter_temperature = -0.8
 spring_temperature = -0.3
 
 # Conversions
-to_summer_temperature = {
-    'default': {
-        'fall': -fall_temperature,
-        'winter': -winter_temperature,
-        'spring': -spring_temperature
+to_summer_temperature: dict[str, dict[str, float]] = {
+    "default": {
+        "fall": -fall_temperature,
+        "winter": -winter_temperature,
+        "spring": -spring_temperature,
     },
-    'summer_rains': {
-        'fall': 0,
-        'winter': 0,
-        'spring': 0
-    }
+    "summer_rains": {"fall": 0, "winter": 0, "spring": 0},
 }
 
 # Permanently summer: warm_ocean, badlands, desert, eroded_badlands, jungle, sparse jungle, mangrove swamp, wooded_badlands
@@ -66,96 +64,51 @@ to_summer_temperature = {
 # default: leaves shift colors, snowy winters, melting spring
 # summer_rains: rain period in summer, dry all other seasons
 
-season_biomes = {
-    'beach': {
-        'v_summer': 'beach',
-        'v_winter': 'snowy_beach'
+season_biomes: dict[str, dict[str, str | dict[str, float] | list[str]]] = {
+    "beach": {"v_summer": "beach", "v_winter": "snowy_beach"},
+    "birch_forest": {"v_summer": "birch_forest"},
+    "ocean": {
+        "v_winter": "cold_ocean",
+        "v_summer": "ocean",
+        "winter": {"temperature": -0.3},
     },
-    'birch_forest': {
-        'v_summer': 'birch_forest'
+    "dark_forest": {"v_summer": "dark_forest"},
+    "deep_ocean": {
+        "v_winter": "deep_cold_ocean",
+        "v_summer": "deep_ocean",
+        "winter": {"temperature": -0.3},
     },
-    'ocean': {
-        'v_winter': 'cold_ocean',
-        'v_summer': 'ocean',
-        'winter': {
-            'temperature': -0.3
-        }
+    "flower_forest": {"v_summer": "flower_forest"},
+    "forest": {"v_summer": "forest"},
+    "peaks": {"v_summer": "stony_peaks", "v_winter": "jagged_peaks"},
+    "river": {"v_summer": "river", "v_winter": "frozen_river"},
+    "grove": {"v_winter": "grove"},
+    "meadow": {"v_summer": "meadow"},
+    "mushroom_fields": {"v_summer": "mushroom_fields"},
+    "old_growth_birch_forest": {"v_summer": "old_growth_birch_forest"},
+    "old_growth_pine_taiga": {"v_fall": "old_growth_pine_taiga"},
+    "old_growth_spruce_taiga": {"v_fall": "old_growth_spruce_taiga"},
+    "plains": {"v_summer": ["plains", "sunflower_plains"], "v_winter": "snowy_plains"},
+    "savanna": {"v_winter": ["savanna", "windswept_savanna"], "type": "summer_rains"},
+    "savanna_plateau": {"v_winter": ["savanna_plateau"], "type": "summer_rains"},
+    "taiga": {
+        "v_summer": "taiga",
+        "v_winter": "snowy_taiga",
+        "default": {"temperature": 0.5},
     },
-    'dark_forest': {
-        'v_summer': 'dark_forest'
+    "stony_shore": {"v_fall": "stony_shore"},
+    "windswept_hills": {
+        "v_spring": ["windswept_forest", "windswept_gravelly_hills", "windswept_hills"]
     },
-    'deep_ocean': {
-        'v_winter': 'deep_cold_ocean',
-        'v_summer': 'deep_ocean',
-        'winter': {
-            'temperature': -0.3
-        }
-    },
-    'flower_forest': {
-        'v_summer': 'flower_forest'
-    },
-    'forest': {
-        'v_summer': 'forest'
-    },
-    'peaks': {
-        'v_summer': 'stony_peaks',
-        'v_winter': 'jagged_peaks'
-    },
-    'river': {
-        'v_summer': 'river',
-        'v_winter': 'frozen_river'
-    },
-    'grove': {
-        'v_winter': 'grove'
-    },
-    'meadow': {
-        'v_summer': 'meadow'
-    },
-    'mushroom_fields': {
-        'v_summer': 'mushroom_fields'
-    },
-    'old_growth_birch_forest': {
-        'v_summer': 'old_growth_birch_forest'
-    },
-    'old_growth_pine_taiga': {
-        'v_fall': 'old_growth_pine_taiga'
-    },
-    'old_growth_spruce_taiga': {
-        'v_fall': 'old_growth_spruce_taiga'
-    },
-    'plains': {
-        'v_summer': ['plains', 'sunflower_plains'],
-        'v_winter': 'snowy_plains'
-    },
-    'savanna': {
-        'v_winter': ['savanna', 'windswept_savanna'],
-        'type': 'summer_rains'
-    },
-    'savanna_plateau': {
-        'v_winter': ['savanna_plateau'],
-        'type': 'summer_rains'
-    },
-    'taiga': {
-        'v_summer': 'taiga',
-        'v_winter': 'snowy_taiga',
-        'default': {
-            'temperature': 0.5
-        }
-    },
-    'stony_shore': {
-        'v_fall': 'stony_shore'
-    },
-    'windswept_hills': {
-        'v_spring': ['windswept_forest', 'windswept_gravelly_hills', 'windswept_hills']
-    }
 }
 
 with open(tag_file) as file:
     data = json.load(file)
-    values = data['values']
+    values = data["values"]
+
 
 def instantiate_template(type, values):
-    folder = template_folder + '/' + type
+    folder = template_folder + "/" + type
     for filename in os.listdir(folder):
         template_path = path.join(folder, filename)
         if not path.isfile(template_path):
@@ -163,31 +116,37 @@ def instantiate_template(type, values):
 
         with open(template_path) as file:
             template = file.read()
-    
-        with open(path.join(output_folder, filename), 'w') as file:
-            for value in values:
-                file.write(template.replace(f'${type}', value))
 
-instantiate_template('plant', values)
+        with open(path.join(output_folder, filename), "w") as file:
+            for value in values:
+                file.write(template.replace(f"${type}", value))
+
+
+instantiate_template("plant", values)
+
 
 def generate_move(template_name: str, output_name: str, max: int, delegate: str):
-    template_path = template_folder + '/move/' + template_name + '.mcfunction'
+    template_path = template_folder + "/move/" + template_name + ".mcfunction"
     with open(template_path) as file:
         template = file.read()
-    pathlib.Path(output_folder + '/move').mkdir(parents=True, exist_ok=True)
+    pathlib.Path(output_folder + "/move").mkdir(parents=True, exist_ok=True)
 
     i = 1
     while i <= max:
-        payload = f'function seasons:generated/move/{output_name}{int(i / 2)}'
+        payload = f"function seasons:generated/move/{output_name}{int(i / 2)}"
         if i == 1:
             payload = delegate
-   
-        with open(path.join(output_folder, f'move/{output_name}{i}.mcfunction'), 'w') as file:
-            file.write(template.replace('$max', str(i)).replace('$payload', payload))
+
+        with open(
+            path.join(output_folder, f"move/{output_name}{i}.mcfunction"), "w"
+        ) as file:
+            file.write(template.replace("$max", str(i)).replace("$payload", payload))
         i *= 2
+
 
 vanilla_grass_image = imageio.imread(vanilla_grass_texture)
 vanilla_foliage_image = imageio.imread(vanilla_foliage_texture)
+
 
 def union(*args) -> list:
     result = []
@@ -195,47 +154,53 @@ def union(*args) -> list:
         result.extend(l)
     return result
 
-def add_if_present(biomes: list, biome: dict, key: str):
+
+def add_if_present(biomes: list, biome: dict, key: str) -> None:
     if key not in biome:
         return
 
     entry = biome[key]
     if isinstance(entry, list):
-        biomes.extend([f'minecraft:{x}' for x in entry])
+        biomes.extend([f"minecraft:{x}" for x in entry])
     else:
-        biomes.append(f'minecraft:{entry}')
+        biomes.append(f"minecraft:{entry}")
 
-def hex_to_rgb(s: str) -> list:
+
+def hex_to_rgb(s: str) -> tuple[float, ...]:
     r = s[0:2]
     g = s[2:4]
     b = s[4:6]
-    return tuple([int(x, 16) / 255.0 for x in [r, g, b]])
+    return tuple(int(x, 16) / 255.0 for x in [r, g, b])
+
 
 def write_tag(id: str, biomes: list):
-    data = {
-        'replace': False,
-        'values': biomes
-    }
-    with open(f'{biome_tag_folder}/{id}.json', 'w') as file:
+    data = {"replace": False, "values": biomes}
+    with open(f"{biome_tag_folder}/{id}.json", "w") as file:
         json.dump(data, file, indent=4)
 
-def create_tags(id, biome, winter_biomes: list, bare_winter_biomes: list, snowy_biomes: list):
-    summer_list = [f'seasons:summer/{id}']
-    fall_list = [f'seasons:fall_early/{id}', f'seasons:fall_late/{id}']
-    bare_winter_biome = f'seasons:winter_bare/{id}'
-    winter_list = [bare_winter_biome, f'seasons:winter_snowy/{id}']
-    melting_list = [f'seasons:winter_melting/{id}']
-    spring_list = [f'seasons:spring_default/{id}', f'seasons:spring_flowering/{id}']
+
+def create_tags(
+    biome_id, biome, winter_biomes: list, bare_winter_biomes: list, snowy_biomes: list
+):
+    summer_list = [f"seasons:summer/{biome_id}"]
+    fall_list = [f"seasons:fall_early/{biome_id}", f"seasons:fall_late/{biome_id}"]
+    bare_winter_biome = f"seasons:winter_bare/{biome_id}"
+    winter_list = [bare_winter_biome, f"seasons:winter_snowy/{biome_id}"]
+    melting_list = [f"seasons:winter_melting/{biome_id}"]
+    spring_list = [
+        f"seasons:spring_default/{biome_id}",
+        f"seasons:spring_flowering/{biome_id}",
+    ]
 
     winter_biomes.extend(winter_list)
     bare_winter_biomes.append(bare_winter_biome)
 
-    vanilla = []
+    vanilla: list[str] = []
     for season in seasons:
-        add_if_present(vanilla, biome, f'v_{season}')
-    
-    type = biome.get('type', 'default')
-    if type == 'default':
+        add_if_present(vanilla, biome, f"v_{season}")
+
+    type = biome.get("type", "default")
+    if type == "default":
         snowy_biomes.extend(winter_list)
 
     non_summer = union(vanilla, fall_list, winter_list, melting_list, spring_list)
@@ -244,25 +209,30 @@ def create_tags(id, biome, winter_biomes: list, bare_winter_biomes: list, snowy_
     non_spring = union(vanilla, summer_list, fall_list, winter_list, melting_list)
     any = union(vanilla, summer_list, fall_list, winter_list, melting_list, spring_list)
 
-    write_tag(f'non_summer/{id}', non_summer)
-    write_tag(f'non_fall/{id}', non_fall)
-    write_tag(f'non_winter/{id}', non_winter)
-    write_tag(f'non_spring/{id}', non_spring)
-    write_tag(f'any/{id}', any)
+    write_tag(f"non_summer/{biome_id}", non_summer)
+    write_tag(f"non_fall/{biome_id}", non_fall)
+    write_tag(f"non_winter/{biome_id}", non_winter)
+    write_tag(f"non_spring/{biome_id}", non_spring)
+    write_tag(f"any/{biome_id}", any)
 
-def int_to_rgb(color: int) -> tuple:
-    r = (color >> 16) & 0xff
-    g = (color >> 8) & 0xff
-    b = color & 0xff
+
+def int_to_rgb(color: int) -> tuple[float, ...]:
+    r = (color >> 16) & 0xFF
+    g = (color >> 8) & 0xFF
+    b = color & 0xFF
     return r / 255.0, g / 255.0, b / 255.0
 
-def rgb_to_int(r: int, g: int, b: int) -> int:
+
+def rgb_to_int(r: float, g: float, b: float) -> int:
     r = r * 255
     g = g * 255
     b = b * 255
-    return ((int(r) & 0xff) << 16) | ((int(g) & 0xff) << 8) | (int(b) & 0xff)
+    return ((int(r) & 0xFF) << 16) | ((int(g) & 0xFF) << 8) | (int(b) & 0xFF)
 
-def calculate_color(downfall: float, temperature: float, colormap: numpy.typing.NDArray) -> int:
+
+def calculate_color(
+    downfall: float, temperature: float, colormap: numpy.typing.NDArray
+) -> int:
     product = downfall * temperature
     x = int((1.0 - temperature) * 255.0)
     y = int((1.0 - product) * 255.0)
@@ -272,7 +242,8 @@ def calculate_color(downfall: float, temperature: float, colormap: numpy.typing.
     pixel = colormap[y, x]
     return rgb_to_int(pixel[0] / 255.0, pixel[1] / 255.0, pixel[2] / 255.0)
 
-def remap_color(color: int, mapping: list) -> int:
+
+def remap_color(color: int, mapping: list[float]) -> int:
     r, g, b = int_to_rgb(color)
     h, s, v = rgb_to_hsv(r, g, b)
     h += mapping[0] / 255.0
@@ -286,37 +257,47 @@ def remap_color(color: int, mapping: list) -> int:
     color = rgb_to_int(r, g, b)
     return color
 
-def load_biome(id: str):
-    filename = f'{vanilla_biome_folder}/{id}.json'
-    with open(filename, 'r') as file:
+
+def load_biome(biome_id: str) -> dict[str, Any]:
+    filename = f"{vanilla_biome_folder}/{biome_id}.json"
+    with open(filename, "r") as file:
         biome = json.load(file)
     set_default_colors(biome)
     return biome
 
-def set_default_colors(biome, override = False):
-    effects = biome['effects']
-    downfall = biome['downfall']
-    temperature = biome['temperature']
-    if 'grass_color' not in effects or override:
-        effects['grass_color'] = calculate_color(downfall, temperature, vanilla_grass_image)
-    if 'foliage_color' not in effects or override:
-        effects['foliage_color'] = calculate_color(downfall, temperature, vanilla_foliage_image)
 
-def get_first_template(biome, season):
-    key = f'v_{season}'
+def set_default_colors(biome, override=False):
+    effects = biome["effects"]
+    downfall = biome["downfall"]
+    temperature = biome["temperature"]
+    if "grass_color" not in effects or override:
+        effects["grass_color"] = calculate_color(
+            downfall, temperature, vanilla_grass_image
+        )
+    if "foliage_color" not in effects or override:
+        effects["foliage_color"] = calculate_color(
+            downfall, temperature, vanilla_foliage_image
+        )
+
+
+def get_first_template(biome: dict, season: str) -> str | None:
+    key = f"v_{season}"
     template = biome.get(key, None)
     if isinstance(template, list):
         return template[0]
     return template
 
+
 def remap(biome, key, mapping):
-    effects = biome['effects']
+    effects = biome["effects"]
     effects[key] = remap_color(effects[key], mapping)
+
 
 def set_color(biome, key, hex):
     r, g, b = hex_to_rgb(hex)
-    effects = biome['effects']
+    effects = biome["effects"]
     effects[key] = rgb_to_int(r, g, b)
+
 
 def apply_overrides(biome_data, conversion, season):
     if not season in conversion:
@@ -324,77 +305,80 @@ def apply_overrides(biome_data, conversion, season):
     for key, item in conversion[season].items():
         biome_data[key] = item
 
-def update_precipitation(biome):
-    if biome['precipitation'] == 'none':
-        return
-    temperature = biome['temperature']
-    if temperature < 0.15:
-        biome['precipitation'] = 'snow'
-    else:
-        biome['precipitation'] = 'rain'
 
-def write_biome(id, biome, season):
-    with open(f'{biome_folder}/{season}/{id}.json', 'w') as file:
+def update_precipitation(biome):
+    if biome["precipitation"] == "none":
+        return
+    temperature = biome["temperature"]
+    if temperature < 0.15:
+        biome["precipitation"] = "snow"
+    else:
+        biome["precipitation"] = "rain"
+
+
+def write_biome(biome_id, biome, season):
+    with open(f"{biome_folder}/{season}/{biome_id}.json", "w") as file:
         json.dump(biome, file, indent=2)
 
-def create_biomes(id: str, biome: dict):
-    type = biome.get('type', 'default')
-    templates = {}
+
+def create_biomes(biome_id: str, biome: dict):
+    biome_type = biome.get("type", "default")
+    templates: dict[str, str | None] = {}
     for season in seasons:
         templates[season] = get_first_template(biome, season)
-    
-    if templates['summer'] is not None:
-        template = load_biome(templates['summer'])
+
+    if templates["summer"] is not None:
+        template = load_biome(templates["summer"])
     else:
         # Try to find a fallback and use as template
         for season in seasons:
             other_template = templates[season]
             if other_template is not None:
                 template = load_biome(other_template)
-                template['temperature'] += to_summer_temperature[type][season]
+                template["temperature"] += to_summer_temperature[biome_type][season]
                 set_default_colors(template)
                 break
 
-    apply_overrides(template, biome, 'default')
+    apply_overrides(template, biome, "default")
 
-    if type == 'default':
+    if biome_type == "default":
         summer = copy.deepcopy(template)
         update_precipitation(summer)
-        write_biome(id, summer, 'summer')
+        write_biome(biome_id, summer, "summer")
 
-        if templates['fall']:
-            fall_template = load_biome(templates['fall'])
+        if templates["fall"]:
+            fall_template = load_biome(templates["fall"])
         else:
             fall_template = None
-        
+
         if fall_template:
             fall_early = copy.deepcopy(fall_template)
         else:
             fall_early = copy.deepcopy(template)
-            fall_early['temperature'] += fall_temperature
-            remap(fall_early, 'grass_color', fall_grass)
-            remap(fall_early, 'sky_color', fall_sky)
+            fall_early["temperature"] += fall_temperature
+            remap(fall_early, "grass_color", fall_grass)
+            remap(fall_early, "sky_color", fall_sky)
         # Vanilla doesn't have fall colors, so just transform as if the template was summer regardless
-        remap(fall_early, 'foliage_color', early_fall_leaves)
-        apply_overrides(fall_early, biome, 'fall')
+        remap(fall_early, "foliage_color", early_fall_leaves)
+        apply_overrides(fall_early, biome, "fall")
         update_precipitation(fall_early)
-        write_biome(id, fall_early, 'fall_early')
+        write_biome(biome_id, fall_early, "fall_early")
 
         if fall_template:
             fall_late = copy.deepcopy(fall_template)
         else:
             fall_late = copy.deepcopy(template)
-            fall_late['temperature'] += fall_temperature
-            remap(fall_late, 'grass_color', fall_grass)
-            remap(fall_late, 'sky_color', fall_sky)
+            fall_late["temperature"] += fall_temperature
+            remap(fall_late, "grass_color", fall_grass)
+            remap(fall_late, "sky_color", fall_sky)
         # Vanilla doesn't have fall colors, so just transform as if the template was summer regardless
-        remap(fall_late, 'foliage_color', late_fall_leaves)
-        apply_overrides(fall_late, biome, 'fall')
+        remap(fall_late, "foliage_color", late_fall_leaves)
+        apply_overrides(fall_late, biome, "fall")
         update_precipitation(fall_late)
-        write_biome(id, fall_late, 'fall_late')
+        write_biome(biome_id, fall_late, "fall_late")
 
-        if templates['winter']:
-            winter_template = load_biome(templates['winter'])
+        if templates["winter"]:
+            winter_template = load_biome(templates["winter"])
         else:
             winter_template = None
 
@@ -402,32 +386,32 @@ def create_biomes(id: str, biome: dict):
             winter_bare = copy.deepcopy(winter_template)
         else:
             winter_bare = copy.deepcopy(template)
-            winter_bare['temperature'] += winter_temperature
-            remap(winter_bare, 'grass_color', winter_grass)
-            remap(winter_bare, 'sky_color', winter_sky)
-        set_color(winter_bare, 'foliage_color', winter_branches)
-        apply_overrides(winter_bare, biome, 'winter')
+            winter_bare["temperature"] += winter_temperature
+            remap(winter_bare, "grass_color", winter_grass)
+            remap(winter_bare, "sky_color", winter_sky)
+        set_color(winter_bare, "foliage_color", winter_branches)
+        apply_overrides(winter_bare, biome, "winter")
         update_precipitation(winter_bare)
-        if winter_bare['precipitation'] != 'snow':
-            print(f'Warning: winter biome for {id} doesnt snow')
-        write_biome(id, winter_bare, 'winter_bare')
+        if winter_bare["precipitation"] != "snow":
+            print(f"Warning: winter biome for {biome_id} doesnt snow")
+        write_biome(biome_id, winter_bare, "winter_bare")
 
         winter_snowy = copy.deepcopy(winter_bare)
-        set_color(winter_snowy, 'grass_color', snowy_ground)
-        set_color(winter_snowy, 'foliage_color', snowy_leaves)
-        write_biome(id, winter_snowy, 'winter_snowy')
+        set_color(winter_snowy, "grass_color", snowy_ground)
+        set_color(winter_snowy, "foliage_color", snowy_leaves)
+        write_biome(biome_id, winter_snowy, "winter_snowy")
 
         winter_melting = copy.deepcopy(winter_snowy)
-        winter_melting['temperature'] = template['temperature'] + spring_temperature
-        if 'spring' in biome and 'temperature' in biome['spring']:
-            winter_melting['temperature'] = biome['spring']['temperature']
+        winter_melting["temperature"] = template["temperature"] + spring_temperature
+        if "spring" in biome and "temperature" in biome["spring"]:
+            winter_melting["temperature"] = biome["spring"]["temperature"]
         update_precipitation(winter_melting)
-        if winter_melting['precipitation'] != 'rain':
-            print(f'Warning: melting winter biome for {id} snows')
-        write_biome(id, winter_melting, 'winter_melting')
+        if winter_melting["precipitation"] != "rain":
+            print(f"Warning: melting winter biome for {biome_id} snows")
+        write_biome(biome_id, winter_melting, "winter_melting")
 
-        if templates['spring']:
-            spring_template = load_biome(templates['spring'])
+        if templates["spring"]:
+            spring_template = load_biome(templates["spring"])
         else:
             spring_template = None
 
@@ -435,50 +419,58 @@ def create_biomes(id: str, biome: dict):
             spring_default = copy.deepcopy(spring_template)
         else:
             spring_default = copy.deepcopy(template)
-            spring_default['temperature'] += spring_temperature
-        remap(spring_default, 'grass_color', spring_grass)
-        remap(spring_default, 'sky_color', spring_sky)
-        remap(spring_default, 'foliage_color', spring_leaves)
-        apply_overrides(spring_default, biome, 'spring')
+            spring_default["temperature"] += spring_temperature
+        remap(spring_default, "grass_color", spring_grass)
+        remap(spring_default, "sky_color", spring_sky)
+        remap(spring_default, "foliage_color", spring_leaves)
+        apply_overrides(spring_default, biome, "spring")
         update_precipitation(spring_default)
-        write_biome(id, spring_default, 'spring_default')
+        write_biome(biome_id, spring_default, "spring_default")
 
         spring_flowering = copy.deepcopy(spring_default)
-        set_color(spring_flowering, 'foliage_color', flowering_leaves)
-        write_biome(id, spring_flowering, 'spring_flowering')
+        set_color(spring_flowering, "foliage_color", flowering_leaves)
+        write_biome(biome_id, spring_flowering, "spring_flowering")
 
-    elif type == 'summer_rains':
+    elif biome_type == "summer_rains":
         dry = copy.deepcopy(template)
-        write_biome(id, dry, 'winter_bare')
-        write_biome(id, dry, 'winter_snowy')
-        write_biome(id, dry, 'winter_melting')
-        write_biome(id, dry, 'spring_default')
-        write_biome(id, dry, 'spring_flowering')
-        write_biome(id, dry, 'fall_early')
-        write_biome(id, dry, 'fall_late')
+        write_biome(biome_id, dry, "winter_bare")
+        write_biome(biome_id, dry, "winter_snowy")
+        write_biome(biome_id, dry, "winter_melting")
+        write_biome(biome_id, dry, "spring_default")
+        write_biome(biome_id, dry, "spring_flowering")
+        write_biome(biome_id, dry, "fall_early")
+        write_biome(biome_id, dry, "fall_late")
         wet = copy.deepcopy(template)
-        wet['downfall'] = 0.75
-        wet['precipitation'] = 'rain'
+        wet["downfall"] = 0.75
+        wet["precipitation"] = "rain"
         set_default_colors(wet, True)
-        write_biome(id, wet, 'summer')
+        write_biome(biome_id, wet, "summer")
 
     else:
-        raise Exception('Unknown type')
+        raise ValueError("Unknown biome type:", biome_type)
 
-winter_biomes = []
-bare_winter_biomes = []
-snowy_biomes = []
-for id, biome in season_biomes.items():
-    create_tags(id, biome, winter_biomes, bare_winter_biomes, snowy_biomes)
-    create_biomes(id, biome)
 
-write_tag(f'winter', winter_biomes)
-write_tag(f'bare_winter', bare_winter_biomes)
-write_tag(f'snowy', snowy_biomes)
+winter_biomes: list[str] = []
+bare_winter_biomes: list[str] = []
+snowy_biomes: list[str] = []
+for biome_id, biome in season_biomes.items():
+    create_tags(biome_id, biome, winter_biomes, bare_winter_biomes, snowy_biomes)
+    create_biomes(biome_id, biome)
 
-instantiate_template('biome', season_biomes.keys())
+write_tag(f"winter", winter_biomes)
+write_tag(f"bare_winter", bare_winter_biomes)
+write_tag(f"snowy", snowy_biomes)
 
-generate_move('z', 'z', 64, 'function seasons:generated/move/x64')
-generate_move('x', 'x', 64, 'execute positioned ~ 319 ~ run function seasons:findsurface')
-generate_move('z', 'blocks_z', 64, 'function seasons:generated/move/blocks_x64')
-generate_move('x', 'blocks_x', 64, 'execute positioned ~ 319 ~ run function seasons:findsurface_blocks')
+instantiate_template("biome", season_biomes.keys())
+
+generate_move("z", "z", 64, "function seasons:generated/move/x64")
+generate_move(
+    "x", "x", 64, "execute positioned ~ 319 ~ run function seasons:findsurface"
+)
+generate_move("z", "blocks_z", 64, "function seasons:generated/move/blocks_x64")
+generate_move(
+    "x",
+    "blocks_x",
+    64,
+    "execute positioned ~ 319 ~ run function seasons:findsurface_blocks",
+)

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+name: seasons
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.11
+  - imageio
+  # development env extras
+  - ipython>=8
+  - jupyterlab>=3
+  - black
+  - isort
+  - jupyterlab_code_formatter
+  - mypy
+  - pytest
+  - nbqa
+  - pip>=22
+  - pre-commit

--- a/package.py
+++ b/package.py
@@ -1,26 +1,42 @@
 import os.path
 from zipfile import ZipFile
 
-def zip(zip_filename, folder, excludes = []):
-    with ZipFile(zip_filename, 'w') as zip:
+
+def zip(zip_filename, folder, excludes=[]):
+    with ZipFile(zip_filename, "w") as zip:
         # Iterate over all the files in directory
         for folder_name, subfolders, filenames in os.walk(folder):
             for filename in filenames:
                 # create complete filepath of file in directory
                 file_path = os.path.join(folder_name, filename)
                 file = os.path.basename(file_path)
-                if file in excludes or file[0] == '.':
+                if file in excludes or file[0] == ".":
                     continue
 
                 relative = os.path.relpath(file_path, folder)
-                if relative[0] == '.':
+                if relative[0] == ".":
                     continue
                 # Add file to zip
-                print(f'{relative}')
+                print(f"{relative}")
                 zip.write(file_path, relative)
 
+
 try:
-    os.remove('seasons.zip')
+    os.remove("seasons.zip")
 except OSError:
     pass
-zip('seasons.zip', '.', ['templates', 'vanilla', 'build.py', 'CONTRIBUTING.md', 'Notes.txt', 'package.py', 'seasons.zip', 'square.jpg', 'square_400.jpg'])
+zip(
+    "seasons.zip",
+    ".",
+    [
+        "templates",
+        "vanilla",
+        "build.py",
+        "CONTRIBUTING.md",
+        "Notes.txt",
+        "package.py",
+        "seasons.zip",
+        "square.jpg",
+        "square_400.jpg",
+    ],
+)


### PR DESCRIPTION
This PR contains three commits which can be cherry-picked separately:

## Development Cruft

a9281631238c44a32ac8068dcc89e99efacac7cf brings over a conda environment YAML and a pre-commit config designed to make it easier for contributors to work on this project and keep their code well-formatted.

## Instructions for Obtaining Vanilla Assets

[The instructions right now](https://github.com/slicedlime/seasons/blob/1b57921a047c2ffb6a7ba474f3bc46dc34507ba5/CONTRIBUTING.md#L16-18) are rather minimal:

> It requires some vanilla files to derive the default values from. Create a 'vanilla' folder and
> copy the default 'foliage.png' and 'grass.png' files from the vanilla resource pack into it. Then
> copy the entire 'worldgen/biome' folder from the vanilla data pack into the folder as 'biome'.

I'm not sure if you're allowed to update the assets in your [`examples` repo](https://github.com/slicedlime/examples), but assuming you're not, I've done my best to give contributors explicit instructions to obtain them legally via 19c261f + fb2bea2. If you choose to leave off the environment YAML above, then the references to a conda environment should be purged or replace with a one-line environment creation command (_e.g._ `mamba create -n seasons python=3.11 imageio`)

## Linting (auto and otherwise)

Using the pre-commit configuration from the first commit, I auto-linted the two python modules and then resolved the remaining `mypy` errors, resulting in 45311d7. If you're disposed to accept these changes, **I strongly urge you to look over the diff** for `build.py` to make sure that the changes match with your intent. ~~as the datapack generated after this commit **does not match** the datapack generated prior to it. I suspect I know which line resulted in the change and will add a comment highlighting it.~~

By ways of validation, I deleted all the worldgen JSON files (`rm data/seasons/worldgen/biome/*/*.json`) theen rebuilt the datapack using `python build.py` on my HEAD, and the freshly-generated files were identical to what you currently have at a5b3663aa8e4c262ccf79f0d5f678c8dde678a06