### PR TITLE
Fix taiga grass colors

### DIFF
--- a/build.py
+++ b/build.py
@@ -263,6 +263,7 @@ def rgb_to_int(r: int, g: int, b: int) -> int:
     return ((int(r) & 0xff) << 16) | ((int(g) & 0xff) << 8) | (int(b) & 0xff)
 
 def calculate_color(downfall: float, temperature: float, colormap: numpy.typing.NDArray) -> int:
+    temperature = max(temperature, 0.0)
     product = downfall * temperature
     x = int((1.0 - temperature) * 255.0)
     y = int((1.0 - product) * 255.0)

--- a/data/seasons/worldgen/biome/fall_early/grove.json
+++ b/data/seasons/worldgen/biome/fall_early/grove.json
@@ -24,8 +24,8 @@
     "sky_color": 10662629,
     "water_color": 4159204,
     "water_fog_color": 329011,
-    "grass_color": 8862962,
-    "foliage_color": 2892112
+    "grass_color": 10594208,
+    "foliage_color": 13759144
   },
   "features": [
     [],

--- a/data/seasons/worldgen/biome/fall_late/grove.json
+++ b/data/seasons/worldgen/biome/fall_late/grove.json
@@ -24,8 +24,8 @@
     "sky_color": 10662629,
     "water_color": 4159204,
     "water_fog_color": 329011,
-    "grass_color": 8862962,
-    "foliage_color": 15301846
+    "grass_color": 10594208,
+    "foliage_color": 7891770
   },
   "features": [
     [],

--- a/data/seasons/worldgen/biome/spring_default/grove.json
+++ b/data/seasons/worldgen/biome/spring_default/grove.json
@@ -24,8 +24,8 @@
     "sky_color": 8495359,
     "water_color": 4159204,
     "water_fog_color": 329011,
-    "grass_color": 16718329,
-    "foliage_color": 5304400
+    "grass_color": 9614497,
+    "foliage_color": 8712882
   },
   "features": [
     [],

--- a/data/seasons/worldgen/biome/spring_flowering/grove.json
+++ b/data/seasons/worldgen/biome/spring_flowering/grove.json
@@ -24,7 +24,7 @@
     "sky_color": 8495359,
     "water_color": 4159204,
     "water_fog_color": 329011,
-    "grass_color": 16718329,
+    "grass_color": 9614497,
     "foliage_color": 16747695
   },
   "features": [

--- a/data/seasons/worldgen/biome/summer/grove.json
+++ b/data/seasons/worldgen/biome/summer/grove.json
@@ -24,8 +24,8 @@
     "sky_color": 8495359,
     "water_color": 4159204,
     "water_fog_color": 329011,
-    "grass_color": -65281,
-    "foliage_color": -65281
+    "grass_color": 8434839,
+    "foliage_color": 6332795
   },
   "features": [
     [],

--- a/data/seasons/worldgen/biome/winter_bare/grove.json
+++ b/data/seasons/worldgen/biome/winter_bare/grove.json
@@ -24,7 +24,7 @@
     "sky_color": 8495359,
     "water_color": 4159204,
     "water_fog_color": 329011,
-    "grass_color": -65281,
+    "grass_color": 8434839,
     "foliage_color": 8153426
   },
   "features": [

--- a/data/seasons/worldgen/biome/winter_bare/peaks.json
+++ b/data/seasons/worldgen/biome/winter_bare/peaks.json
@@ -24,7 +24,7 @@
     "sky_color": 8756735,
     "water_color": 4159204,
     "water_fog_color": 329011,
-    "grass_color": -65281,
+    "grass_color": 8434839,
     "foliage_color": 8153426
   },
   "features": [

--- a/data/seasons/worldgen/biome/winter_bare/taiga.json
+++ b/data/seasons/worldgen/biome/winter_bare/taiga.json
@@ -18,7 +18,7 @@
     "sky_color": 8625919,
     "water_color": 4020182,
     "water_fog_color": 329011,
-    "grass_color": -65281,
+    "grass_color": 8434839,
     "foliage_color": 8153426
   },
   "features": [


### PR DESCRIPTION
Fixes #4. The generator's calculate_color function returned magenta if the biome's `temperature` was below 0, so now the function sets the `temperature` value to 0 if it is below 0 before calculating the color.