### PR TITLE
Support of 1.19.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vanilla
 seasons.zip
 credentials.json
+__pycache__

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This is a datapack that adds seasonal shifts to vanilla Minecraft, made by slice
 
 This datapack uses experimental world generation features to create seasonal variations of the
 vanilla biomes. Because those features are experimental, the pack is expected to break with every
-new version of Minecraft. It currently works with Minecraft 1.19.3 (and no other known version).
-In specific: it does **not** work with pre-release version of Minecraf 1.19.4.
+new version of Minecraft. It currently works with Minecraft 1.19.4+ (and no other known version).
+In specific: it does **not** work with 1.19.3 and before (all versions that use datapacks with version 10 or earlier).
 
 This also means that levels with the pack on will show a warning screen for of it using
 experimental features.

--- a/build.py
+++ b/build.py
@@ -328,13 +328,21 @@ def apply_overrides(biome_data, conversion, season):
         biome_data[key] = item
 
 def update_precipitation(biome):
-    if 'precipitation' in biome:
-        biome.pop('precipitation')
     temperature = biome['temperature']
+    # 1.19.3- (precipitation)
+    if temperature < 0.15:
+        biome['precipitation'] = 'snow'
+    elif temperature >= 2.0:
+        biome['precipitation'] = 'none'
+    else:
+        biome['precipitation'] = 'rain'
+    # 1.19.4+ (has_precipitation)
     if temperature >= 2.0:
         biome['has_precipitation'] = False
         return
     biome['has_precipitation'] = True
+
+    
 
 def write_biome(id, biome, season):
     folder = f'{biome_folder}/{season}'
@@ -412,7 +420,7 @@ def create_biomes(id: str, biome: dict):
         set_color(winter_bare, 'foliage_color', winter_branches)
         apply_overrides(winter_bare, biome, 'winter')
         update_precipitation(winter_bare)
-        if winter_bare['temperature'] >= 0.15:
+        if winter_bare['temperature'] >= 0.15 or winter_bare['precipitation'] != 'snow':
             print(f'Warning: winter biome for {id} doesnt snow')
         write_biome(id, winter_bare, 'winter_bare')
 
@@ -426,7 +434,7 @@ def create_biomes(id: str, biome: dict):
         if 'spring' in biome and 'temperature' in biome['spring']:
             winter_melting['temperature'] = biome['spring']['temperature']
         update_precipitation(winter_melting)
-        if winter_melting['temperature'] < 0.15:
+        if winter_melting['temperature'] < 0.15 or winter_melting['precipitation'] != 'rain':
             print(f'Warning: melting winter biome for {id} snows')
         write_biome(id, winter_melting, 'winter_melting')
 
@@ -462,6 +470,7 @@ def create_biomes(id: str, biome: dict):
         write_biome(id, dry, 'fall_late')
         wet = copy.deepcopy(template)
         wet['downfall'] = 0.75
+        wet['precipitation'] = 'rain'
         wet['has_precipitation'] = True
         set_default_colors(wet, True)
         write_biome(id, wet, 'summer')
@@ -472,9 +481,7 @@ def create_biomes(id: str, biome: dict):
 winter_biomes = []
 bare_winter_biomes = []
 snowy_biomes = []
-i=0
 for id, biome in season_biomes.items():
-    i+=1
     create_tags(id, biome, winter_biomes, bare_winter_biomes, snowy_biomes)
     create_biomes(id, biome)
 

--- a/build.py
+++ b/build.py
@@ -331,12 +331,10 @@ def update_precipitation(biome):
     if 'precipitation' in biome:
         biome.pop('precipitation')
     temperature = biome['temperature']
-    if temperature < 0.15:
-        # Snow precipitation
+    if temperature >= 2.0:
         biome['has_precipitation'] = False
-    else:
-        # Rain precipitation
-        biome['has_precipitation'] = True
+        return
+    biome['has_precipitation'] = True
 
 def write_biome(id, biome, season):
     folder = f'{biome_folder}/{season}'
@@ -363,7 +361,6 @@ def create_biomes(id: str, biome: dict):
                 break
 
     apply_overrides(template, biome, 'default')
-
     if type == 'default':
         summer = copy.deepcopy(template)
         update_precipitation(summer)
@@ -415,7 +412,7 @@ def create_biomes(id: str, biome: dict):
         set_color(winter_bare, 'foliage_color', winter_branches)
         apply_overrides(winter_bare, biome, 'winter')
         update_precipitation(winter_bare)
-        if winter_bare['has_precipitation']:
+        if winter_bare['temperature'] >= 0.15:
             print(f'Warning: winter biome for {id} doesnt snow')
         write_biome(id, winter_bare, 'winter_bare')
 
@@ -429,7 +426,7 @@ def create_biomes(id: str, biome: dict):
         if 'spring' in biome and 'temperature' in biome['spring']:
             winter_melting['temperature'] = biome['spring']['temperature']
         update_precipitation(winter_melting)
-        if not winter_melting['has_precipitation']:
+        if winter_melting['temperature'] < 0.15:
             print(f'Warning: melting winter biome for {id} snows')
         write_biome(id, winter_melting, 'winter_melting')
 
@@ -475,7 +472,9 @@ def create_biomes(id: str, biome: dict):
 winter_biomes = []
 bare_winter_biomes = []
 snowy_biomes = []
+i=0
 for id, biome in season_biomes.items():
+    i+=1
     create_tags(id, biome, winter_biomes, bare_winter_biomes, snowy_biomes)
     create_biomes(id, biome)
 

--- a/build.py
+++ b/build.py
@@ -328,13 +328,15 @@ def apply_overrides(biome_data, conversion, season):
         biome_data[key] = item
 
 def update_precipitation(biome):
-    if biome['precipitation'] == 'none':
-        return
+    if 'precipitation' in biome:
+        biome.pop('precipitation')
     temperature = biome['temperature']
     if temperature < 0.15:
-        biome['precipitation'] = 'snow'
+        # Snow precipitation
+        biome['has_precipitation'] = False
     else:
-        biome['precipitation'] = 'rain'
+        # Rain precipitation
+        biome['has_precipitation'] = True
 
 def write_biome(id, biome, season):
     folder = f'{biome_folder}/{season}'
@@ -413,7 +415,7 @@ def create_biomes(id: str, biome: dict):
         set_color(winter_bare, 'foliage_color', winter_branches)
         apply_overrides(winter_bare, biome, 'winter')
         update_precipitation(winter_bare)
-        if winter_bare['precipitation'] != 'snow':
+        if winter_bare['has_precipitation']:
             print(f'Warning: winter biome for {id} doesnt snow')
         write_biome(id, winter_bare, 'winter_bare')
 
@@ -427,7 +429,7 @@ def create_biomes(id: str, biome: dict):
         if 'spring' in biome and 'temperature' in biome['spring']:
             winter_melting['temperature'] = biome['spring']['temperature']
         update_precipitation(winter_melting)
-        if winter_melting['precipitation'] != 'rain':
+        if not winter_melting['has_precipitation']:
             print(f'Warning: melting winter biome for {id} snows')
         write_biome(id, winter_melting, 'winter_melting')
 
@@ -463,7 +465,7 @@ def create_biomes(id: str, biome: dict):
         write_biome(id, dry, 'fall_late')
         wet = copy.deepcopy(template)
         wet['downfall'] = 0.75
-        wet['precipitation'] = 'rain'
+        wet['has_precipitation'] = True
         set_default_colors(wet, True)
         write_biome(id, wet, 'summer')
 

--- a/data/seasons/worldgen/biome/fall_early/beach.json
+++ b/data/seasons/worldgen/biome/fall_early/beach.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/beach.json
+++ b/data/seasons/worldgen/biome/fall_early/beach.json
@@ -166,5 +166,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.4
+  "temperature": 0.4,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/birch_forest.json
+++ b/data/seasons/worldgen/biome/fall_early/birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/birch_forest.json
+++ b/data/seasons/worldgen/biome/fall_early/birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.19999999999999996
+  "temperature": 0.19999999999999996,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/dark_forest.json
+++ b/data/seasons/worldgen/biome/fall_early/dark_forest.json
@@ -93,7 +93,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/dark_forest.json
+++ b/data/seasons/worldgen/biome/fall_early/dark_forest.json
@@ -193,5 +193,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.29999999999999993
+  "temperature": 0.29999999999999993,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/deep_ocean.json
+++ b/data/seasons/worldgen/biome/fall_early/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/deep_ocean.json
+++ b/data/seasons/worldgen/biome/fall_early/deep_ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_early/deep_ocean.json
+++ b/data/seasons/worldgen/biome/fall_early/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/flower_forest.json
+++ b/data/seasons/worldgen/biome/fall_early/flower_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/flower_forest.json
+++ b/data/seasons/worldgen/biome/fall_early/flower_forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.29999999999999993
+  "temperature": 0.29999999999999993,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/forest.json
+++ b/data/seasons/worldgen/biome/fall_early/forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/forest.json
+++ b/data/seasons/worldgen/biome/fall_early/forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.29999999999999993
+  "temperature": 0.29999999999999993,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/grove.json
+++ b/data/seasons/worldgen/biome/fall_early/grove.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/grove.json
+++ b/data/seasons/worldgen/biome/fall_early/grove.json
@@ -209,5 +209,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.20000000000000007
+  "temperature": 0.20000000000000007,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/meadow.json
+++ b/data/seasons/worldgen/biome/fall_early/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/meadow.json
+++ b/data/seasons/worldgen/biome/fall_early/meadow.json
@@ -185,5 +185,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_early/meadow.json
+++ b/data/seasons/worldgen/biome/fall_early/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/fall_early/mushroom_fields.json
@@ -83,7 +83,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/fall_early/mushroom_fields.json
@@ -116,5 +116,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/ocean.json
+++ b/data/seasons/worldgen/biome/fall_early/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/ocean.json
+++ b/data/seasons/worldgen/biome/fall_early/ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_early/ocean.json
+++ b/data/seasons/worldgen/biome/fall_early/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/fall_early/old_growth_birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/fall_early/old_growth_birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.19999999999999996
+  "temperature": 0.19999999999999996,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/fall_early/old_growth_pine_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/fall_early/old_growth_pine_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3
+  "temperature": 0.3,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/fall_early/old_growth_spruce_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/fall_early/old_growth_spruce_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.25
+  "temperature": 0.25,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/peaks.json
+++ b/data/seasons/worldgen/biome/fall_early/peaks.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/peaks.json
+++ b/data/seasons/worldgen/biome/fall_early/peaks.json
@@ -162,5 +162,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.6
+  "temperature": 0.6,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/plains.json
+++ b/data/seasons/worldgen/biome/fall_early/plains.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/plains.json
+++ b/data/seasons/worldgen/biome/fall_early/plains.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.4
+  "temperature": 0.4,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/river.json
+++ b/data/seasons/worldgen/biome/fall_early/river.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/river.json
+++ b/data/seasons/worldgen/biome/fall_early/river.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/river.json
+++ b/data/seasons/worldgen/biome/fall_early/river.json
@@ -181,5 +181,6 @@
       }
     ]
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_early/savanna.json
+++ b/data/seasons/worldgen/biome/fall_early/savanna.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/savanna_plateau.json
+++ b/data/seasons/worldgen/biome/fall_early/savanna_plateau.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/stony_shore.json
+++ b/data/seasons/worldgen/biome/fall_early/stony_shore.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/stony_shore.json
+++ b/data/seasons/worldgen/biome/fall_early/stony_shore.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_early/taiga.json
+++ b/data/seasons/worldgen/biome/fall_early/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/taiga.json
+++ b/data/seasons/worldgen/biome/fall_early/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/taiga.json
+++ b/data/seasons/worldgen/biome/fall_early/taiga.json
@@ -205,5 +205,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_early/windswept_hills.json
+++ b/data/seasons/worldgen/biome/fall_early/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/windswept_hills.json
+++ b/data/seasons/worldgen/biome/fall_early/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_early/windswept_hills.json
+++ b/data/seasons/worldgen/biome/fall_early/windswept_hills.json
@@ -194,5 +194,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_late/beach.json
+++ b/data/seasons/worldgen/biome/fall_late/beach.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/beach.json
+++ b/data/seasons/worldgen/biome/fall_late/beach.json
@@ -166,5 +166,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.4
+  "temperature": 0.4,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/birch_forest.json
+++ b/data/seasons/worldgen/biome/fall_late/birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/birch_forest.json
+++ b/data/seasons/worldgen/biome/fall_late/birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.19999999999999996
+  "temperature": 0.19999999999999996,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/dark_forest.json
+++ b/data/seasons/worldgen/biome/fall_late/dark_forest.json
@@ -93,7 +93,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/dark_forest.json
+++ b/data/seasons/worldgen/biome/fall_late/dark_forest.json
@@ -193,5 +193,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.29999999999999993
+  "temperature": 0.29999999999999993,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/deep_ocean.json
+++ b/data/seasons/worldgen/biome/fall_late/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/deep_ocean.json
+++ b/data/seasons/worldgen/biome/fall_late/deep_ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_late/deep_ocean.json
+++ b/data/seasons/worldgen/biome/fall_late/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/flower_forest.json
+++ b/data/seasons/worldgen/biome/fall_late/flower_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/flower_forest.json
+++ b/data/seasons/worldgen/biome/fall_late/flower_forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.29999999999999993
+  "temperature": 0.29999999999999993,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/forest.json
+++ b/data/seasons/worldgen/biome/fall_late/forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/forest.json
+++ b/data/seasons/worldgen/biome/fall_late/forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.29999999999999993
+  "temperature": 0.29999999999999993,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/grove.json
+++ b/data/seasons/worldgen/biome/fall_late/grove.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/grove.json
+++ b/data/seasons/worldgen/biome/fall_late/grove.json
@@ -209,5 +209,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.20000000000000007
+  "temperature": 0.20000000000000007,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/meadow.json
+++ b/data/seasons/worldgen/biome/fall_late/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/meadow.json
+++ b/data/seasons/worldgen/biome/fall_late/meadow.json
@@ -185,5 +185,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_late/meadow.json
+++ b/data/seasons/worldgen/biome/fall_late/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/fall_late/mushroom_fields.json
@@ -83,7 +83,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/fall_late/mushroom_fields.json
@@ -116,5 +116,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/ocean.json
+++ b/data/seasons/worldgen/biome/fall_late/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/ocean.json
+++ b/data/seasons/worldgen/biome/fall_late/ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_late/ocean.json
+++ b/data/seasons/worldgen/biome/fall_late/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/fall_late/old_growth_birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/fall_late/old_growth_birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.19999999999999996
+  "temperature": 0.19999999999999996,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/fall_late/old_growth_pine_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/fall_late/old_growth_pine_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3
+  "temperature": 0.3,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/fall_late/old_growth_spruce_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/fall_late/old_growth_spruce_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.25
+  "temperature": 0.25,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/peaks.json
+++ b/data/seasons/worldgen/biome/fall_late/peaks.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/peaks.json
+++ b/data/seasons/worldgen/biome/fall_late/peaks.json
@@ -162,5 +162,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.6
+  "temperature": 0.6,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/plains.json
+++ b/data/seasons/worldgen/biome/fall_late/plains.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/plains.json
+++ b/data/seasons/worldgen/biome/fall_late/plains.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.4
+  "temperature": 0.4,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/river.json
+++ b/data/seasons/worldgen/biome/fall_late/river.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/river.json
+++ b/data/seasons/worldgen/biome/fall_late/river.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/river.json
+++ b/data/seasons/worldgen/biome/fall_late/river.json
@@ -181,5 +181,6 @@
       }
     ]
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_late/savanna.json
+++ b/data/seasons/worldgen/biome/fall_late/savanna.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/savanna_plateau.json
+++ b/data/seasons/worldgen/biome/fall_late/savanna_plateau.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/stony_shore.json
+++ b/data/seasons/worldgen/biome/fall_late/stony_shore.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/stony_shore.json
+++ b/data/seasons/worldgen/biome/fall_late/stony_shore.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/fall_late/taiga.json
+++ b/data/seasons/worldgen/biome/fall_late/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/taiga.json
+++ b/data/seasons/worldgen/biome/fall_late/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/taiga.json
+++ b/data/seasons/worldgen/biome/fall_late/taiga.json
@@ -205,5 +205,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/fall_late/windswept_hills.json
+++ b/data/seasons/worldgen/biome/fall_late/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/windswept_hills.json
+++ b/data/seasons/worldgen/biome/fall_late/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/fall_late/windswept_hills.json
+++ b/data/seasons/worldgen/biome/fall_late/windswept_hills.json
@@ -194,5 +194,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/spring_default/beach.json
+++ b/data/seasons/worldgen/biome/spring_default/beach.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/beach.json
+++ b/data/seasons/worldgen/biome/spring_default/beach.json
@@ -166,5 +166,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/birch_forest.json
+++ b/data/seasons/worldgen/biome/spring_default/birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/birch_forest.json
+++ b/data/seasons/worldgen/biome/spring_default/birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3
+  "temperature": 0.3,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/dark_forest.json
+++ b/data/seasons/worldgen/biome/spring_default/dark_forest.json
@@ -93,7 +93,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/dark_forest.json
+++ b/data/seasons/worldgen/biome/spring_default/dark_forest.json
@@ -193,5 +193,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/deep_ocean.json
+++ b/data/seasons/worldgen/biome/spring_default/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/deep_ocean.json
+++ b/data/seasons/worldgen/biome/spring_default/deep_ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/flower_forest.json
+++ b/data/seasons/worldgen/biome/spring_default/flower_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/flower_forest.json
+++ b/data/seasons/worldgen/biome/spring_default/flower_forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/forest.json
+++ b/data/seasons/worldgen/biome/spring_default/forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/forest.json
+++ b/data/seasons/worldgen/biome/spring_default/forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/grove.json
+++ b/data/seasons/worldgen/biome/spring_default/grove.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/grove.json
+++ b/data/seasons/worldgen/biome/spring_default/grove.json
@@ -209,5 +209,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3000000000000001
+  "temperature": 0.3000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/meadow.json
+++ b/data/seasons/worldgen/biome/spring_default/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/meadow.json
+++ b/data/seasons/worldgen/biome/spring_default/meadow.json
@@ -185,5 +185,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/spring_default/mushroom_fields.json
@@ -83,7 +83,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/spring_default/mushroom_fields.json
@@ -116,5 +116,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.6000000000000001
+  "temperature": 0.6000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/ocean.json
+++ b/data/seasons/worldgen/biome/spring_default/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/ocean.json
+++ b/data/seasons/worldgen/biome/spring_default/ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/spring_default/old_growth_birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/spring_default/old_growth_birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3
+  "temperature": 0.3,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/spring_default/old_growth_pine_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/spring_default/old_growth_pine_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/spring_default/old_growth_spruce_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/spring_default/old_growth_spruce_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.35000000000000003
+  "temperature": 0.35000000000000003,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/peaks.json
+++ b/data/seasons/worldgen/biome/spring_default/peaks.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/peaks.json
+++ b/data/seasons/worldgen/biome/spring_default/peaks.json
@@ -162,5 +162,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.7
+  "temperature": 0.7,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/plains.json
+++ b/data/seasons/worldgen/biome/spring_default/plains.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/plains.json
+++ b/data/seasons/worldgen/biome/spring_default/plains.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/river.json
+++ b/data/seasons/worldgen/biome/spring_default/river.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/river.json
+++ b/data/seasons/worldgen/biome/spring_default/river.json
@@ -181,5 +181,6 @@
       }
     ]
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/savanna.json
+++ b/data/seasons/worldgen/biome/spring_default/savanna.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/savanna_plateau.json
+++ b/data/seasons/worldgen/biome/spring_default/savanna_plateau.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/stony_shore.json
+++ b/data/seasons/worldgen/biome/spring_default/stony_shore.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/stony_shore.json
+++ b/data/seasons/worldgen/biome/spring_default/stony_shore.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3000000000000001
+  "temperature": 0.3000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/taiga.json
+++ b/data/seasons/worldgen/biome/spring_default/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/taiga.json
+++ b/data/seasons/worldgen/biome/spring_default/taiga.json
@@ -205,5 +205,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_default/windswept_hills.json
+++ b/data/seasons/worldgen/biome/spring_default/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_default/windswept_hills.json
+++ b/data/seasons/worldgen/biome/spring_default/windswept_hills.json
@@ -194,5 +194,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/beach.json
+++ b/data/seasons/worldgen/biome/spring_flowering/beach.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/beach.json
+++ b/data/seasons/worldgen/biome/spring_flowering/beach.json
@@ -166,5 +166,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/birch_forest.json
+++ b/data/seasons/worldgen/biome/spring_flowering/birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/birch_forest.json
+++ b/data/seasons/worldgen/biome/spring_flowering/birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3
+  "temperature": 0.3,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/dark_forest.json
+++ b/data/seasons/worldgen/biome/spring_flowering/dark_forest.json
@@ -93,7 +93,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/dark_forest.json
+++ b/data/seasons/worldgen/biome/spring_flowering/dark_forest.json
@@ -193,5 +193,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/deep_ocean.json
+++ b/data/seasons/worldgen/biome/spring_flowering/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/deep_ocean.json
+++ b/data/seasons/worldgen/biome/spring_flowering/deep_ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/flower_forest.json
+++ b/data/seasons/worldgen/biome/spring_flowering/flower_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/flower_forest.json
+++ b/data/seasons/worldgen/biome/spring_flowering/flower_forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/forest.json
+++ b/data/seasons/worldgen/biome/spring_flowering/forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/forest.json
+++ b/data/seasons/worldgen/biome/spring_flowering/forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/grove.json
+++ b/data/seasons/worldgen/biome/spring_flowering/grove.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/grove.json
+++ b/data/seasons/worldgen/biome/spring_flowering/grove.json
@@ -209,5 +209,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3000000000000001
+  "temperature": 0.3000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/meadow.json
+++ b/data/seasons/worldgen/biome/spring_flowering/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/meadow.json
+++ b/data/seasons/worldgen/biome/spring_flowering/meadow.json
@@ -185,5 +185,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/spring_flowering/mushroom_fields.json
@@ -83,7 +83,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/spring_flowering/mushroom_fields.json
@@ -116,5 +116,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.6000000000000001
+  "temperature": 0.6000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/ocean.json
+++ b/data/seasons/worldgen/biome/spring_flowering/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/ocean.json
+++ b/data/seasons/worldgen/biome/spring_flowering/ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/spring_flowering/old_growth_birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/spring_flowering/old_growth_birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3
+  "temperature": 0.3,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/spring_flowering/old_growth_pine_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/spring_flowering/old_growth_pine_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/spring_flowering/old_growth_spruce_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/spring_flowering/old_growth_spruce_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.35000000000000003
+  "temperature": 0.35000000000000003,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/peaks.json
+++ b/data/seasons/worldgen/biome/spring_flowering/peaks.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/peaks.json
+++ b/data/seasons/worldgen/biome/spring_flowering/peaks.json
@@ -162,5 +162,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.7
+  "temperature": 0.7,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/plains.json
+++ b/data/seasons/worldgen/biome/spring_flowering/plains.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/plains.json
+++ b/data/seasons/worldgen/biome/spring_flowering/plains.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/river.json
+++ b/data/seasons/worldgen/biome/spring_flowering/river.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/river.json
+++ b/data/seasons/worldgen/biome/spring_flowering/river.json
@@ -181,5 +181,6 @@
       }
     ]
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/savanna.json
+++ b/data/seasons/worldgen/biome/spring_flowering/savanna.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/savanna_plateau.json
+++ b/data/seasons/worldgen/biome/spring_flowering/savanna_plateau.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/stony_shore.json
+++ b/data/seasons/worldgen/biome/spring_flowering/stony_shore.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/stony_shore.json
+++ b/data/seasons/worldgen/biome/spring_flowering/stony_shore.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3000000000000001
+  "temperature": 0.3000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/taiga.json
+++ b/data/seasons/worldgen/biome/spring_flowering/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/taiga.json
+++ b/data/seasons/worldgen/biome/spring_flowering/taiga.json
@@ -205,5 +205,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/spring_flowering/windswept_hills.json
+++ b/data/seasons/worldgen/biome/spring_flowering/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/spring_flowering/windswept_hills.json
+++ b/data/seasons/worldgen/biome/spring_flowering/windswept_hills.json
@@ -194,5 +194,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/beach.json
+++ b/data/seasons/worldgen/biome/summer/beach.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/beach.json
+++ b/data/seasons/worldgen/biome/summer/beach.json
@@ -166,5 +166,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.8
+  "temperature": 0.8,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/birch_forest.json
+++ b/data/seasons/worldgen/biome/summer/birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/birch_forest.json
+++ b/data/seasons/worldgen/biome/summer/birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.6
+  "temperature": 0.6,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/dark_forest.json
+++ b/data/seasons/worldgen/biome/summer/dark_forest.json
@@ -93,7 +93,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/dark_forest.json
+++ b/data/seasons/worldgen/biome/summer/dark_forest.json
@@ -193,5 +193,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.7
+  "temperature": 0.7,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/deep_ocean.json
+++ b/data/seasons/worldgen/biome/summer/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/deep_ocean.json
+++ b/data/seasons/worldgen/biome/summer/deep_ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/flower_forest.json
+++ b/data/seasons/worldgen/biome/summer/flower_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/flower_forest.json
+++ b/data/seasons/worldgen/biome/summer/flower_forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.7
+  "temperature": 0.7,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/forest.json
+++ b/data/seasons/worldgen/biome/summer/forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/forest.json
+++ b/data/seasons/worldgen/biome/summer/forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.7
+  "temperature": 0.7,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/grove.json
+++ b/data/seasons/worldgen/biome/summer/grove.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/grove.json
+++ b/data/seasons/worldgen/biome/summer/grove.json
@@ -209,5 +209,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.6000000000000001
+  "temperature": 0.6000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/meadow.json
+++ b/data/seasons/worldgen/biome/summer/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/meadow.json
+++ b/data/seasons/worldgen/biome/summer/meadow.json
@@ -185,5 +185,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/summer/mushroom_fields.json
@@ -83,7 +83,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/summer/mushroom_fields.json
@@ -116,5 +116,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.9
+  "temperature": 0.9,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/ocean.json
+++ b/data/seasons/worldgen/biome/summer/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/ocean.json
+++ b/data/seasons/worldgen/biome/summer/ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/summer/old_growth_birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/summer/old_growth_birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.6
+  "temperature": 0.6,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/summer/old_growth_pine_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/summer/old_growth_pine_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.7
+  "temperature": 0.7,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/summer/old_growth_spruce_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/summer/old_growth_spruce_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.65
+  "temperature": 0.65,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/peaks.json
+++ b/data/seasons/worldgen/biome/summer/peaks.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/peaks.json
+++ b/data/seasons/worldgen/biome/summer/peaks.json
@@ -162,5 +162,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 1.0
+  "temperature": 1.0,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/plains.json
+++ b/data/seasons/worldgen/biome/summer/plains.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/plains.json
+++ b/data/seasons/worldgen/biome/summer/plains.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.8
+  "temperature": 0.8,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/river.json
+++ b/data/seasons/worldgen/biome/summer/river.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/river.json
+++ b/data/seasons/worldgen/biome/summer/river.json
@@ -181,5 +181,6 @@
       }
     ]
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/savanna.json
+++ b/data/seasons/worldgen/biome/summer/savanna.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/savanna.json
+++ b/data/seasons/worldgen/biome/summer/savanna.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 2.0
+  "temperature": 2.0,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/savanna_plateau.json
+++ b/data/seasons/worldgen/biome/summer/savanna_plateau.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/savanna_plateau.json
+++ b/data/seasons/worldgen/biome/summer/savanna_plateau.json
@@ -204,5 +204,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 2.0
+  "temperature": 2.0,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/stony_shore.json
+++ b/data/seasons/worldgen/biome/summer/stony_shore.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/stony_shore.json
+++ b/data/seasons/worldgen/biome/summer/stony_shore.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.6000000000000001
+  "temperature": 0.6000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/taiga.json
+++ b/data/seasons/worldgen/biome/summer/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/taiga.json
+++ b/data/seasons/worldgen/biome/summer/taiga.json
@@ -205,5 +205,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/summer/windswept_hills.json
+++ b/data/seasons/worldgen/biome/summer/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/summer/windswept_hills.json
+++ b/data/seasons/worldgen/biome/summer/windswept_hills.json
@@ -194,5 +194,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_bare/beach.json
+++ b/data/seasons/worldgen/biome/winter_bare/beach.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/beach.json
+++ b/data/seasons/worldgen/biome/winter_bare/beach.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.05
+  "temperature": 0.05,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/beach.json
+++ b/data/seasons/worldgen/biome/winter_bare/beach.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.20000000000000007
+  "temperature": -0.20000000000000007,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/dark_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/dark_forest.json
@@ -93,7 +93,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/dark_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/dark_forest.json
@@ -193,5 +193,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.10000000000000009
+  "temperature": -0.10000000000000009,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/dark_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/dark_forest.json
@@ -93,7 +93,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/deep_ocean.json
+++ b/data/seasons/worldgen/biome/winter_bare/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/deep_ocean.json
+++ b/data/seasons/worldgen/biome/winter_bare/deep_ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": -0.3
+  "temperature": -0.3,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/deep_ocean.json
+++ b/data/seasons/worldgen/biome/winter_bare/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/flower_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/flower_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/flower_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/flower_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/flower_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/flower_forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.10000000000000009
+  "temperature": -0.10000000000000009,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.10000000000000009
+  "temperature": -0.10000000000000009,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/grove.json
+++ b/data/seasons/worldgen/biome/winter_bare/grove.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/grove.json
+++ b/data/seasons/worldgen/biome/winter_bare/grove.json
@@ -209,5 +209,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.2
+  "temperature": -0.2,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/grove.json
+++ b/data/seasons/worldgen/biome/winter_bare/grove.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/meadow.json
+++ b/data/seasons/worldgen/biome/winter_bare/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/meadow.json
+++ b/data/seasons/worldgen/biome/winter_bare/meadow.json
@@ -185,5 +185,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.30000000000000004
+  "temperature": -0.30000000000000004,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/meadow.json
+++ b/data/seasons/worldgen/biome/winter_bare/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/winter_bare/mushroom_fields.json
@@ -83,7 +83,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/winter_bare/mushroom_fields.json
@@ -83,7 +83,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/winter_bare/mushroom_fields.json
@@ -116,5 +116,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/ocean.json
+++ b/data/seasons/worldgen/biome/winter_bare/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/ocean.json
+++ b/data/seasons/worldgen/biome/winter_bare/ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": -0.3
+  "temperature": -0.3,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/ocean.json
+++ b/data/seasons/worldgen/biome/winter_bare/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/old_growth_birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/old_growth_birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_bare/old_growth_birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.20000000000000007
+  "temperature": -0.20000000000000007,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/winter_bare/old_growth_pine_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/winter_bare/old_growth_pine_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.10000000000000009
+  "temperature": -0.10000000000000009,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/winter_bare/old_growth_pine_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/winter_bare/old_growth_spruce_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/winter_bare/old_growth_spruce_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.15000000000000002
+  "temperature": -0.15000000000000002,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/winter_bare/old_growth_spruce_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/peaks.json
+++ b/data/seasons/worldgen/biome/winter_bare/peaks.json
@@ -170,5 +170,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.7
+  "temperature": -0.7,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/peaks.json
+++ b/data/seasons/worldgen/biome/winter_bare/peaks.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/peaks.json
+++ b/data/seasons/worldgen/biome/winter_bare/peaks.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/plains.json
+++ b/data/seasons/worldgen/biome/winter_bare/plains.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/plains.json
+++ b/data/seasons/worldgen/biome/winter_bare/plains.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/plains.json
+++ b/data/seasons/worldgen/biome/winter_bare/plains.json
@@ -180,5 +180,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.0
+  "temperature": 0.0,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/river.json
+++ b/data/seasons/worldgen/biome/winter_bare/river.json
@@ -85,7 +85,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/river.json
+++ b/data/seasons/worldgen/biome/winter_bare/river.json
@@ -85,7 +85,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/river.json
+++ b/data/seasons/worldgen/biome/winter_bare/river.json
@@ -180,5 +180,6 @@
       }
     ]
   },
-  "temperature": 0.0
+  "temperature": 0.0,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/savanna.json
+++ b/data/seasons/worldgen/biome/winter_bare/savanna.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/savanna_plateau.json
+++ b/data/seasons/worldgen/biome/winter_bare/savanna_plateau.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/stony_shore.json
+++ b/data/seasons/worldgen/biome/winter_bare/stony_shore.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/stony_shore.json
+++ b/data/seasons/worldgen/biome/winter_bare/stony_shore.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.19999999999999996
+  "temperature": -0.19999999999999996,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/stony_shore.json
+++ b/data/seasons/worldgen/biome/winter_bare/stony_shore.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/taiga.json
+++ b/data/seasons/worldgen/biome/winter_bare/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/taiga.json
+++ b/data/seasons/worldgen/biome/winter_bare/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/taiga.json
+++ b/data/seasons/worldgen/biome/winter_bare/taiga.json
@@ -205,5 +205,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.5
+  "temperature": -0.5,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/windswept_hills.json
+++ b/data/seasons/worldgen/biome/winter_bare/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_bare/windswept_hills.json
+++ b/data/seasons/worldgen/biome/winter_bare/windswept_hills.json
@@ -194,5 +194,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.30000000000000004
+  "temperature": -0.30000000000000004,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_bare/windswept_hills.json
+++ b/data/seasons/worldgen/biome/winter_bare/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/beach.json
+++ b/data/seasons/worldgen/biome/winter_melting/beach.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/beach.json
+++ b/data/seasons/worldgen/biome/winter_melting/beach.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_melting/birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_melting/birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3
+  "temperature": 0.3,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/dark_forest.json
+++ b/data/seasons/worldgen/biome/winter_melting/dark_forest.json
@@ -93,7 +93,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/dark_forest.json
+++ b/data/seasons/worldgen/biome/winter_melting/dark_forest.json
@@ -193,5 +193,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/deep_ocean.json
+++ b/data/seasons/worldgen/biome/winter_melting/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/deep_ocean.json
+++ b/data/seasons/worldgen/biome/winter_melting/deep_ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/flower_forest.json
+++ b/data/seasons/worldgen/biome/winter_melting/flower_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/flower_forest.json
+++ b/data/seasons/worldgen/biome/winter_melting/flower_forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/forest.json
+++ b/data/seasons/worldgen/biome/winter_melting/forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/forest.json
+++ b/data/seasons/worldgen/biome/winter_melting/forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/grove.json
+++ b/data/seasons/worldgen/biome/winter_melting/grove.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/grove.json
+++ b/data/seasons/worldgen/biome/winter_melting/grove.json
@@ -209,5 +209,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3000000000000001
+  "temperature": 0.3000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/meadow.json
+++ b/data/seasons/worldgen/biome/winter_melting/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/meadow.json
+++ b/data/seasons/worldgen/biome/winter_melting/meadow.json
@@ -185,5 +185,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/winter_melting/mushroom_fields.json
@@ -83,7 +83,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/winter_melting/mushroom_fields.json
@@ -116,5 +116,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.6000000000000001
+  "temperature": 0.6000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/ocean.json
+++ b/data/seasons/worldgen/biome/winter_melting/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/ocean.json
+++ b/data/seasons/worldgen/biome/winter_melting/ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_melting/old_growth_birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_melting/old_growth_birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3
+  "temperature": 0.3,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/winter_melting/old_growth_pine_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/winter_melting/old_growth_pine_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.39999999999999997
+  "temperature": 0.39999999999999997,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/winter_melting/old_growth_spruce_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/winter_melting/old_growth_spruce_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.35000000000000003
+  "temperature": 0.35000000000000003,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/peaks.json
+++ b/data/seasons/worldgen/biome/winter_melting/peaks.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/peaks.json
+++ b/data/seasons/worldgen/biome/winter_melting/peaks.json
@@ -170,5 +170,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.7
+  "temperature": 0.7,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/plains.json
+++ b/data/seasons/worldgen/biome/winter_melting/plains.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/plains.json
+++ b/data/seasons/worldgen/biome/winter_melting/plains.json
@@ -180,5 +180,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.5
+  "temperature": 0.5,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/river.json
+++ b/data/seasons/worldgen/biome/winter_melting/river.json
@@ -85,7 +85,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/river.json
+++ b/data/seasons/worldgen/biome/winter_melting/river.json
@@ -180,5 +180,6 @@
       }
     ]
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/savanna.json
+++ b/data/seasons/worldgen/biome/winter_melting/savanna.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/savanna_plateau.json
+++ b/data/seasons/worldgen/biome/winter_melting/savanna_plateau.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/stony_shore.json
+++ b/data/seasons/worldgen/biome/winter_melting/stony_shore.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/stony_shore.json
+++ b/data/seasons/worldgen/biome/winter_melting/stony_shore.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.3000000000000001
+  "temperature": 0.3000000000000001,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/taiga.json
+++ b/data/seasons/worldgen/biome/winter_melting/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/taiga.json
+++ b/data/seasons/worldgen/biome/winter_melting/taiga.json
@@ -205,5 +205,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_melting/windswept_hills.json
+++ b/data/seasons/worldgen/biome/winter_melting/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_melting/windswept_hills.json
+++ b/data/seasons/worldgen/biome/winter_melting/windswept_hills.json
@@ -194,5 +194,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.2
+  "temperature": 0.2,
+  "precipitation": "rain"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/beach.json
+++ b/data/seasons/worldgen/biome/winter_snowy/beach.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/beach.json
+++ b/data/seasons/worldgen/biome/winter_snowy/beach.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.05
+  "temperature": 0.05,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/beach.json
+++ b/data/seasons/worldgen/biome/winter_snowy/beach.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.20000000000000007
+  "temperature": -0.20000000000000007,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/dark_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/dark_forest.json
@@ -93,7 +93,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/dark_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/dark_forest.json
@@ -193,5 +193,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.10000000000000009
+  "temperature": -0.10000000000000009,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/dark_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/dark_forest.json
@@ -93,7 +93,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/deep_ocean.json
+++ b/data/seasons/worldgen/biome/winter_snowy/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/deep_ocean.json
+++ b/data/seasons/worldgen/biome/winter_snowy/deep_ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": -0.3
+  "temperature": -0.3,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/deep_ocean.json
+++ b/data/seasons/worldgen/biome/winter_snowy/deep_ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/flower_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/flower_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/flower_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/flower_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/flower_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/flower_forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.10000000000000009
+  "temperature": -0.10000000000000009,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/forest.json
@@ -198,5 +198,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.10000000000000009
+  "temperature": -0.10000000000000009,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/grove.json
+++ b/data/seasons/worldgen/biome/winter_snowy/grove.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/grove.json
+++ b/data/seasons/worldgen/biome/winter_snowy/grove.json
@@ -209,5 +209,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.2
+  "temperature": -0.2,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/grove.json
+++ b/data/seasons/worldgen/biome/winter_snowy/grove.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/meadow.json
+++ b/data/seasons/worldgen/biome/winter_snowy/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/meadow.json
+++ b/data/seasons/worldgen/biome/winter_snowy/meadow.json
@@ -185,5 +185,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.30000000000000004
+  "temperature": -0.30000000000000004,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/meadow.json
+++ b/data/seasons/worldgen/biome/winter_snowy/meadow.json
@@ -91,7 +91,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/winter_snowy/mushroom_fields.json
@@ -83,7 +83,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/winter_snowy/mushroom_fields.json
@@ -83,7 +83,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/mushroom_fields.json
+++ b/data/seasons/worldgen/biome/winter_snowy/mushroom_fields.json
@@ -116,5 +116,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.09999999999999998
+  "temperature": 0.09999999999999998,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/ocean.json
+++ b/data/seasons/worldgen/biome/winter_snowy/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/ocean.json
+++ b/data/seasons/worldgen/biome/winter_snowy/ocean.json
@@ -189,5 +189,6 @@
       }
     ]
   },
-  "temperature": -0.3
+  "temperature": -0.3,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/ocean.json
+++ b/data/seasons/worldgen/biome/winter_snowy/ocean.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/old_growth_birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/old_growth_birch_forest.json
@@ -92,7 +92,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/old_growth_birch_forest.json
+++ b/data/seasons/worldgen/biome/winter_snowy/old_growth_birch_forest.json
@@ -192,5 +192,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.20000000000000007
+  "temperature": -0.20000000000000007,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/winter_snowy/old_growth_pine_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/winter_snowy/old_growth_pine_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.10000000000000009
+  "temperature": -0.10000000000000009,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/old_growth_pine_taiga.json
+++ b/data/seasons/worldgen/biome/winter_snowy/old_growth_pine_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/winter_snowy/old_growth_spruce_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/winter_snowy/old_growth_spruce_taiga.json
@@ -215,5 +215,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.15000000000000002
+  "temperature": -0.15000000000000002,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/old_growth_spruce_taiga.json
+++ b/data/seasons/worldgen/biome/winter_snowy/old_growth_spruce_taiga.json
@@ -97,7 +97,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/peaks.json
+++ b/data/seasons/worldgen/biome/winter_snowy/peaks.json
@@ -170,5 +170,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.7
+  "temperature": -0.7,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/peaks.json
+++ b/data/seasons/worldgen/biome/winter_snowy/peaks.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/peaks.json
+++ b/data/seasons/worldgen/biome/winter_snowy/peaks.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/plains.json
+++ b/data/seasons/worldgen/biome/winter_snowy/plains.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/plains.json
+++ b/data/seasons/worldgen/biome/winter_snowy/plains.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/plains.json
+++ b/data/seasons/worldgen/biome/winter_snowy/plains.json
@@ -180,5 +180,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": 0.0
+  "temperature": 0.0,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/river.json
+++ b/data/seasons/worldgen/biome/winter_snowy/river.json
@@ -85,7 +85,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/river.json
+++ b/data/seasons/worldgen/biome/winter_snowy/river.json
@@ -85,7 +85,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/river.json
+++ b/data/seasons/worldgen/biome/winter_snowy/river.json
@@ -180,5 +180,6 @@
       }
     ]
   },
-  "temperature": 0.0
+  "temperature": 0.0,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/savanna.json
+++ b/data/seasons/worldgen/biome/winter_snowy/savanna.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/savanna_plateau.json
+++ b/data/seasons/worldgen/biome/winter_snowy/savanna_plateau.json
@@ -86,7 +86,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/stony_shore.json
+++ b/data/seasons/worldgen/biome/winter_snowy/stony_shore.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/stony_shore.json
+++ b/data/seasons/worldgen/biome/winter_snowy/stony_shore.json
@@ -159,5 +159,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.19999999999999996
+  "temperature": -0.19999999999999996,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/stony_shore.json
+++ b/data/seasons/worldgen/biome/winter_snowy/stony_shore.json
@@ -84,7 +84,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/taiga.json
+++ b/data/seasons/worldgen/biome/winter_snowy/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/taiga.json
+++ b/data/seasons/worldgen/biome/winter_snowy/taiga.json
@@ -87,7 +87,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/taiga.json
+++ b/data/seasons/worldgen/biome/winter_snowy/taiga.json
@@ -205,5 +205,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.5
+  "temperature": -0.5,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/windswept_hills.json
+++ b/data/seasons/worldgen/biome/winter_snowy/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "has_precipitation": false,
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/seasons/worldgen/biome/winter_snowy/windswept_hills.json
+++ b/data/seasons/worldgen/biome/winter_snowy/windswept_hills.json
@@ -194,5 +194,6 @@
     "water_ambient": [],
     "water_creature": []
   },
-  "temperature": -0.30000000000000004
+  "temperature": -0.30000000000000004,
+  "precipitation": "snow"
 }

--- a/data/seasons/worldgen/biome/winter_snowy/windswept_hills.json
+++ b/data/seasons/worldgen/biome/winter_snowy/windswept_hills.json
@@ -88,7 +88,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "snow",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 10,
-    "description": "Seasons Beta 0.1 by slicedlime"
+    "pack_format": 12,
+    "description": "Seasons Beta 0.2 by slicedlime"
   }
 }


### PR DESCRIPTION
I updated the datapack to work with 1.19.4 by supporting the new precipitation system brought with snapshot 23w03a.

In `build.py`, the script remove all "precipitation" field in biomes.
If the **temperature** of a biome is less than 0.15, the field **has_precipitation** will be set to **false** otherwise it will be set to **true**.

It's possible that I didn't understand exactly how this change works, but it works.