### PR TITLE
26.2 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minecraft Seasons datapack
 
-This is a datapack that adds seasonal shifts to vanilla Minecraft, made by slicedlime.
+This is a datapack that adds seasonal shifts to vanilla Minecraft, made by slicedlime (upgraded to newer version by jcrayb).
 
 ## Features
 
@@ -20,7 +20,7 @@ This is a datapack that adds seasonal shifts to vanilla Minecraft, made by slice
 
 This datapack uses experimental world generation features to create seasonal variations of the
 vanilla biomes. Because those features are experimental, the pack is expected to break with every
-new version of Minecraft. It currently works with Minecraft 1.21.5 (and no other known version).
+new version of Minecraft. It currently works with Minecraft 1.21.5-26.2 (releases available in "Releases" tab).
 
 This also means that levels with the pack on will show a warning screen for of it using
 experimental features.

--- a/data/minecraft/wolf_variant/ashen.json
+++ b/data/minecraft/wolf_variant/ashen.json
@@ -4,6 +4,11 @@
     "tame": "minecraft:entity/wolf/wolf_ashen_tame",
     "wild": "minecraft:entity/wolf/wolf_ashen"
   },
+  "baby_assets": {
+    "angry": "minecraft:entity/wolf/wolf_ashen_angry_baby",
+    "tame": "minecraft:entity/wolf/wolf_ashen_tame_baby",
+    "wild": "minecraft:entity/wolf/wolf_ashen_baby"
+  },
   "spawn_conditions": [
     {
       "condition": {

--- a/data/minecraft/wolf_variant/black.json
+++ b/data/minecraft/wolf_variant/black.json
@@ -4,6 +4,11 @@
     "tame": "minecraft:entity/wolf/wolf_black_tame",
     "wild": "minecraft:entity/wolf/wolf_black"
   },
+  "baby_assets": {
+    "angry": "minecraft:entity/wolf/wolf_black_angry_baby",
+    "tame": "minecraft:entity/wolf/wolf_black_tame_baby",
+    "wild": "minecraft:entity/wolf/wolf_black_baby"
+  },
   "spawn_conditions": [
     {
       "condition": {

--- a/data/minecraft/wolf_variant/chestnut.json
+++ b/data/minecraft/wolf_variant/chestnut.json
@@ -4,6 +4,11 @@
     "tame": "minecraft:entity/wolf/wolf_chestnut_tame",
     "wild": "minecraft:entity/wolf/wolf_chestnut"
   },
+  "baby_assets": {
+    "angry": "minecraft:entity/wolf/wolf_chestnut_angry_baby",
+    "tame": "minecraft:entity/wolf/wolf_chestnut_tame_baby",
+    "wild": "minecraft:entity/wolf/wolf_chestnut_baby"
+  },
   "spawn_conditions": [
     {
       "condition": {

--- a/data/minecraft/wolf_variant/snowy.json
+++ b/data/minecraft/wolf_variant/snowy.json
@@ -4,6 +4,11 @@
     "tame": "minecraft:entity/wolf/wolf_snowy_tame",
     "wild": "minecraft:entity/wolf/wolf_snowy"
   },
+  "baby_assets": {
+    "angry": "minecraft:entity/wolf/wolf_snowy_angry_baby",
+    "tame": "minecraft:entity/wolf/wolf_snowy_tame_baby",
+    "wild": "minecraft:entity/wolf/wolf_snowy_baby"
+  },
   "spawn_conditions": [
     {
       "condition": {

--- a/data/minecraft/wolf_variant/woods.json
+++ b/data/minecraft/wolf_variant/woods.json
@@ -4,6 +4,11 @@
     "tame": "minecraft:entity/wolf/wolf_woods_tame",
     "wild": "minecraft:entity/wolf/wolf_woods"
   },
+  "baby_assets": {
+    "angry": "minecraft:entity/wolf/wolf_woods_angry_baby",
+    "tame": "minecraft:entity/wolf/wolf_woods_tame_baby",
+    "wild": "minecraft:entity/wolf/wolf_woods_baby"
+  },
   "spawn_conditions": [
     {
       "condition": {

--- a/data/seasons/function/load.mcfunction
+++ b/data/seasons/function/load.mcfunction
@@ -11,4 +11,4 @@ execute if score BlockSpeed _seasons matches 0 run scoreboard players set BlockS
 scoreboard players add Range _seasons 0
 execute if score Range _seasons matches 0 run scoreboard players set Range _seasons 12
 
-gamerule snowAccumulationHeight 8
+gamerule max_snow_accumulation_height 8

--- a/data/seasons/function/tick.mcfunction
+++ b/data/seasons/function/tick.mcfunction
@@ -3,7 +3,7 @@
 scoreboard players operation YearLength _seasons = SeasonLength _seasons
 scoreboard players operation YearLength _seasons *= SeasonCount _seasons
 
-execute store result score Day _seasons run time query day
+execute store result score Day _seasons run time query day repetition
 execute store result storage seasons:random range int 16 run scoreboard players get Range _seasons
 
 scoreboard players operation Day _seasons %= YearLength _seasons

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,7 @@
 {
   "pack": {
-    "pack_format": 71,
+    "min_format": 88,
+    "max_format": 107.1,
     "description": "Seasons Beta 0.6 by slicedlime"
   }
 }

--- a/package.py
+++ b/package.py
@@ -1,5 +1,6 @@
 import os.path
 from zipfile import ZipFile
+import sys
 
 def in_excluded_folder(file, excludes):
     excluded_folders = [x for x in excludes if x[-1] == '/']
@@ -31,4 +32,4 @@ try:
     os.remove('seasons.zip')
 except OSError:
     pass
-zip('seasons.zip', '.', ['templates/', 'vanilla/', 'build.py', 'CONTRIBUTING.md', 'Notes.txt', 'package.py', 'seasons.zip', 'credentials.json', 'metadata.json'])
+zip(f'seasons{"_"+sys.argv[1] if len(sys.argv) >= 2 else ""}.zip', '.', ['templates/', 'vanilla/', 'build.py', 'CONTRIBUTING.md', 'Notes.txt', 'package.py', 'seasons.zip', 'credentials.json', 'metadata.json'])


### PR DESCRIPTION
Made some changes to the code to allow it to run on worlds running 26.2. Confirmed it by running it in solo world that previously was running 1.21.9, and nothing broke. Changes are:

1. Added baby variants to wolves
2. Changed variable name from `snowAccumulationHeight` to `max_snow_accumulation_height` in `seasons/function/load.mcfunction`
3. Changed `pack_format` to the new min/max format nomenclature. Min is set to 88.0 because originally I ported the pack over to 1.21.9. However, changing the var name and the baby wolf variants make it so the pack can't actually be loaded in 1.21.9 in its current form, and vice versa. So maybe we can make separate releases?